### PR TITLE
Copy attribute list so we do not modify in place when renaming attributes.

### DIFF
--- a/core/folioxml/src/folioxml/export/html/HtmlTidy.java
+++ b/core/folioxml/src/folioxml/export/html/HtmlTidy.java
@@ -31,8 +31,12 @@ public class HtmlTidy implements NodeListProcessor, ExportingNodeListProcessor {
                 provider.getNamedStream("tidy_invalid_elements").append(n.toXmlString(true)).append("\n");
             }
 
+            // copy the attribute list so we are not modifying in place
+            List<Map.Entry<String, String>> attrs = new ArrayList<Map.Entry<String, String>>();
+            for (Map.Entry<String,String> e : n.getAttributes().entrySet()) {
+                attrs.add(new java.util.AbstractMap.SimpleEntry<String, String>(e));
+            }
 
-            List<Map.Entry<String, String>> attrs = new ArrayList<Map.Entry<String, String>>(n.getAttributes().entrySet());
             //First check for invalid attributes, and print them.
             for (Map.Entry<String, String> pair : attrs) {
                 if (!validAttributes.contains(pair.getKey()) && !invalidAttributes.contains(pair.getKey())) {

--- a/core/folioxml/testsrc/folioxml/export/html/HtmlTidyTest.java
+++ b/core/folioxml/testsrc/folioxml/export/html/HtmlTidyTest.java
@@ -1,0 +1,56 @@
+package folioxml.export.html;
+
+import folioxml.core.InvalidMarkupException;
+import folioxml.export.LogStreamProvider;
+import folioxml.xml.NodeList;
+import folioxml.xml.XmlRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+public class HtmlTidyTest {
+
+    private HtmlTidy htmlTidy;
+
+    @Before
+    public void Setup() {
+        htmlTidy = new HtmlTidy();
+        htmlTidy.setLogProvider(new NopLogStreamProvider());
+    }
+    @Test
+    public void TestInvalidAttributesAreRenamed() throws IOException, InvalidMarkupException {
+        XmlRecord record = new XmlRecord("<div folioId=\"1\" groups=\"2017,public\" id=\"r1\" level=\"Year\" uri=\"2017#ar1\">");
+        htmlTidy.process(new NodeList(singletonList(record)));
+        assertEquals("<div data-folioId=\"1\" data-groups=\"2017,public\" data-level=\"Year\" data-uri=\"2017#ar1\" id=\"r1\"></div>", record.toXmlString(false));
+    }
+}
+
+class NopLogStreamProvider implements LogStreamProvider {
+
+    @Override
+    public Appendable getNamedStream(String name) throws IOException {
+        return new NilAppendable();
+    }
+}
+
+class NilAppendable implements Appendable {
+
+    @Override
+    public Appendable append(CharSequence csq) throws IOException {
+        return this;
+    }
+
+    @Override
+    public Appendable append(CharSequence csq, int start, int end) throws IOException {
+        return this;
+    }
+
+    @Override
+    public Appendable append(char c) throws IOException {
+        return this;
+    }
+}


### PR DESCRIPTION
Address an issue in HTMLTidy whereby attributes would fail to be processed correctly due to modification of the underlying collection whilst iterating through the list of attributes.

Fix is to copy the attribute list before processing it.